### PR TITLE
fix: bump engraft to 0.2.2 (fixes silent no-op via npx)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,7 @@ jobs:
       - run: mv www animals
 
       # Build "leon" variant via engraft
-      # NOTE: invoking via `node ...cli.js` (not `npx engraft`) — npm bin
-      # symlink trips a broken isMain() check in @smartcompanion/engraft@0.2.1
-      # and the CLI silently exits 0 without applying anything.
-      - run: node ./node_modules/@smartcompanion/engraft/dist/cli.js apply --template engraft.template.yml --values customization/leon/engraft.variables.yml
+      - run: npx engraft apply --template engraft.template.yml --values customization/leon/engraft.variables.yml
       - run: grep -q 'Leon Audioguide' src/index.html
       - run: npm run build
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,11 @@ jobs:
       - run: mv www animals
 
       # Build "leon" variant via engraft
-      - run: npx engraft apply --template engraft.template.yml --values customization/leon/engraft.variables.yml
+      # NOTE: invoking via `node ...cli.js` (not `npx engraft`) — npm bin
+      # symlink trips a broken isMain() check in @smartcompanion/engraft@0.2.1
+      # and the CLI silently exits 0 without applying anything.
+      - run: node ./node_modules/@smartcompanion/engraft/dist/cli.js apply --template engraft.template.yml --values customization/leon/engraft.variables.yml
+      - run: grep -q 'Leon Audioguide' src/index.html
       - run: npm run build
       - run: |
           sed -i 's|"/build/|"build/|g' www/index.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@capacitor/share": "^8.0.1",
         "@ionic/core": "^8.6.0",
         "@smartcompanion/data": "^0.8.0",
-        "@smartcompanion/engraft": "^0.2.1",
+        "@smartcompanion/engraft": "^0.2.2",
         "@smartcompanion/native-audio-player": "^0.4.0",
         "@smartcompanion/services": "^0.8.0",
         "@smartcompanion/ui": "^0.8.0",
@@ -3944,9 +3944,9 @@
       }
     },
     "node_modules/@smartcompanion/engraft": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@smartcompanion/engraft/-/engraft-0.2.1.tgz",
-      "integrity": "sha512-DAkcSMSSmkvykMQtqjAqDvnvE4LummjW+XPJcGOaBUEBBX2ge8WbQ08UFjo7Y5PcQzpHGfjkqZ/1bQgtrYmZ+g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@smartcompanion/engraft/-/engraft-0.2.2.tgz",
+      "integrity": "sha512-ZN25S43NugjkxFwOFHJS/xfeMH8D4g4SHELYXkEuskvSUfR4U6tVlkxDVXYNN0BOHDnRfDO0F/09PHLGEQxMUg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@capacitor/share": "^8.0.1",
     "@ionic/core": "^8.6.0",
     "@smartcompanion/data": "^0.8.0",
-    "@smartcompanion/engraft": "^0.2.1",
+    "@smartcompanion/engraft": "^0.2.2",
     "@smartcompanion/native-audio-player": "^0.4.0",
     "@smartcompanion/services": "^0.8.0",
     "@smartcompanion/ui": "^0.8.0",


### PR DESCRIPTION
## Summary
The deployed `leon` variant from the previous release came out identical to `animals` because the engraft step was a silent no-op. Root cause was an `isMain()` bug in `@smartcompanion/engraft@0.2.1`: when invoked through `node_modules/.bin/engraft` (as `npx` does), the resolved `import.meta.url` path didn't match the unresolved `process.argv[1]` symlink path, so the CLI exited 0 without parsing any arguments or applying anything.

Upstream fix landed in `@smartcompanion/engraft@0.2.2`. This PR:

- Bumps the devDependency to `^0.2.2`.
- Restores the simple `npx engraft apply …` invocation in `release.yml`.
- Keeps a `grep -q 'Leon Audioguide' src/index.html` post-condition so any future silent regression fails the build loudly instead of shipping the wrong site.

## Verification
- Reproduced the original silent no-op against `0.2.1` via `npx engraft`.
- Reran `npx engraft apply --template engraft.template.yml --values customization/leon/engraft.variables.yml` against `0.2.2` in a clean copy of the tree:
  - `Done. Customizations applied successfully.` printed
  - `stencil.config.ts`, `index.html`, `manifest.json`, `app.scss` all show leon values
  - `npm run build` on the customized tree succeeds; `www/manifest.json` and `www/index.html` reflect leon

## Test plan
- [x] `npx engraft apply …` actually mutates source files on `0.2.2`
- [x] `npm run build` succeeds on the engraft-customized leon tree
- [x] grep guard passes locally and would fail loudly if engraft regressed again
- [ ] Cut a release after merge and verify `/audioguide-app/leon/` actually serves the leon content

🤖 Generated with [Claude Code](https://claude.com/claude-code)